### PR TITLE
moves bulletins as resources under groups

### DIFF
--- a/app/controllers/v1/bulletins_controller.rb
+++ b/app/controllers/v1/bulletins_controller.rb
@@ -1,6 +1,7 @@
 class V1::BulletinsController < ApplicationController
   serialization_scope nil
 
+  before_action :set_group
   before_action :set_bulletin, only: [:create]
 
   def show
@@ -24,6 +25,11 @@ class V1::BulletinsController < ApplicationController
     @bulletin.display_published_at = user_params[:publishedAt]
     @bulletin.description = user_params[:description]
     @bulletin.service_order = user_params[:serviceOrder]
+    @bulletin.group = @group
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 
   def user_params

--- a/app/models/bulletin.rb
+++ b/app/models/bulletin.rb
@@ -2,6 +2,7 @@ class Bulletin < ActiveRecord::Base
   belongs_to :group
   before_save :populate_published_at
   validate :display_published_at_must_be_correct_format
+  validates :group, presence: true
 
   attr_accessor :display_published_at
 

--- a/app/serializers/bulletin_serializer.rb
+++ b/app/serializers/bulletin_serializer.rb
@@ -1,5 +1,10 @@
 class BulletinSerializer < ActiveModel::Serializer
-  attributes :id, :published_at, :name, :service_order, :description
+  attributes :id,
+             :published_at,
+             :name,
+             :service_order,
+             :description,
+             :group
 
   def published_at
     object.published_at.utc.to_time.iso8601

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -1,5 +1,5 @@
 class GroupSerializer < ActiveModel::Serializer
-  attributes :name, :created_at
+  attributes :id, :name, :created_at
 
   def created_at
     object.created_at.utc.to_time.iso8601

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,9 @@ Rails.application.routes.draw do
   devise_for :users
 
   namespace :v1, defaults: { format: 'json' } do
-    resources :groups
-    resources :bulletins
+    resources :groups do
+      resources :bulletins
+    end
   end
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/spec/controllers/v1/bulletins_controller_spec.rb
+++ b/spec/controllers/v1/bulletins_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 describe V1::BulletinsController do
+  let(:sunday_service) do
+    create(:group)
+  end
+
   let(:valid_attributes) do
     {
       bulletin: {
@@ -8,51 +12,44 @@ describe V1::BulletinsController do
         name: Forgery(:lorem_ipsum).title,
         description: Forgery(:lorem_ipsum).words(10),
         serviceOrder: Forgery(:lorem_ipsum).words(10)
-      }
+      },
+      group_id: sunday_service.id
     }
   end
 
-  describe 'GET /bulletins/:id' do
+  describe 'GET /:group_slug/bulletins/:id' do
     let(:bulletin) { create(:bulletin) }
 
     it 'returns a single bulletin' do
-      get :show, id: bulletin.id
+      get :show, id: bulletin.id, group_id: bulletin.group_id
       expect(response.body).to eq(BulletinSerializer.new(bulletin).to_json)
     end
   end
 
-  describe 'POST /bulletins' do
+  describe 'POST /:group_slug/bulletins' do
     context 'with valid params' do
-      let(:create) { post :create, valid_attributes }
+      let(:perform_create) { post :create, valid_attributes }
 
       it 'creates a new bulletin' do
-        expect { create }.to change { Bulletin.count }.by(1)
+        expect { perform_create }.to change { Bulletin.count }.by(1)
       end
 
       it 'returns the created bulletin' do
-        create
+        perform_create
 
-        bulletin_hash = valid_attributes[:bulletin]
-
-        bulletin = Bulletin.new
-        bulletin.id = Bulletin.last.id
-        bulletin.name = bulletin_hash[:name]
-        bulletin.published_at = DateTime.iso8601(bulletin_hash[:publishedAt])
-        bulletin.description = bulletin_hash[:description]
-        bulletin.service_order = bulletin_hash[:serviceOrder]
-
-        expect(response.body).to eq(BulletinSerializer.new(bulletin).to_json)
+        expect(response.body).
+            to eq(BulletinSerializer.new(Bulletin.last).to_json)
       end
     end
 
     context 'with invalid parameters' do
       let(:invalid_attributes) { valid_attributes }
-      let(:create) { post :create, valid_attributes }
+      let(:perform_create) { post :create, valid_attributes }
 
       context "where published_at is not iso8601 compliant" do
         before do
           invalid_attributes[:bulletin][:publishedAt] = 'sdafasdfdsa'
-          create
+          perform_create
         end
 
         subject { response }

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :group do
-    name 'Test Group'
+    name Forgery(:lorem_ipsum).title
   end
 end

--- a/spec/models/bulletin_spec.rb
+++ b/spec/models/bulletin_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Bulletin, :type => :model do
   end
 
   context "validation" do
-    let(:bulletin) { create(:bulletin, display_published_at: 'asdasf') }
-
     it 'requires a valid date' do
       expect(build(:bulletin, display_published_at: '')).to_not be_valid
+    end
+
+    it 'requires a group' do
+      expect(build(:bulletin, group: nil)).to_not be_valid
     end
   end
 end

--- a/spec/serializers/bulletin_serializer_spec.rb
+++ b/spec/serializers/bulletin_serializer_spec.rb
@@ -4,6 +4,7 @@ require 'rspec/its'
 describe BulletinSerializer do
   let(:bulletin) { create(:bulletin) }
   let(:bulletin_json) { JSON.parse(BulletinSerializer.new(bulletin).to_json) }
+
   subject { bulletin_json['bulletin'] }
 
   it 'has a "bulletin" root element' do
@@ -14,5 +15,11 @@ describe BulletinSerializer do
   its(['serviceOrder']) { should eq(bulletin.service_order) }
   its(['publishedAt']) { should eq(bulletin.published_at.utc.to_time.iso8601) }
   its(['description']) { should eq(bulletin.description) }
+
+  context 'with a group' do
+    let(:group) { bulletin.group }
+    let(:group_json) { JSON.parse(GroupSerializer.new(group).to_json) }
+    it_behaves_like 'a serialized group'
+  end
 end
 

--- a/spec/serializers/group_serializer_spec.rb
+++ b/spec/serializers/group_serializer_spec.rb
@@ -4,12 +4,6 @@ require 'rspec/its'
 describe GroupSerializer do
   let(:group) { create(:group) }
   let(:group_json) { JSON.parse(GroupSerializer.new(group).to_json) }
-  subject { group_json['group'] }
 
-  it 'has a "group" root element' do
-    expect(group_json).to have_key('group')
-  end
-
-  its(['name']) { should eq(group.name) }
-  its(['createdAt']) { should eq(group.created_at.utc.to_time.iso8601) }
+  it_behaves_like 'a serialized group'
 end

--- a/spec/support/shared_examples/serialized_group.rb
+++ b/spec/support/shared_examples/serialized_group.rb
@@ -1,0 +1,13 @@
+# expects group_json
+#         group
+shared_examples 'a serialized group' do
+  subject { group_json['group'] }
+
+  it 'has a "group" root element' do
+    expect(group_json).to have_key('group')
+  end
+
+  its(['id']) { should eq(group.id) }
+  its(['name']) { should eq(group.name) }
+  its(['createdAt']) { should eq(group.created_at.utc.to_time.iso8601) }
+end


### PR DESCRIPTION
Bulletins now get their group from the id provided in the url.
