### PR TITLE
removes session api token from user serializer

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,5 @@
+class SessionsController < Devise::SessionsController
+  def default_serializer_options
+    { serializer: LoggedUserSerializer, root: 'user' }
+  end
+end

--- a/app/serializers/logged_user_serializer.rb
+++ b/app/serializers/logged_user_serializer.rb
@@ -1,0 +1,4 @@
+class LoggedUserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+  has_one :session_api_key
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :name, :email
-  has_one :session_api_key
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   resources :api_keys, except: [:new, :edit]
-  devise_for :users
+  devise_for :users, controllers: { sessions: 'sessions' }
 
   namespace :v1, defaults: { format: 'json' } do
     resources :groups do

--- a/spec/serializers/logged_user_serializer_spec.rb
+++ b/spec/serializers/logged_user_serializer_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+require 'rspec/its'
+
+describe LoggedUserSerializer do
+  let(:user) { create(:user) }
+  let(:user_json) { JSON.parse(LoggedUserSerializer.new(user).to_json) }
+
+  subject { user_json['loggedUser'] }
+
+  it 'has a "user" root element' do
+    expect(user_json).to have_key('loggedUser')
+  end
+
+  its(['id']) { should eq(user.id) }
+  its(['name']) { should eq(user.name) }
+  its(['email']) { should eq(user.email) }
+
+  context 'with a session api key' do
+    let(:api_key) { user.session_api_key }
+    let(:api_key_json) { user_json['loggedUser'] }
+    let(:expected_root_key) { 'sessionApiKey' }
+
+    it_behaves_like 'a serialized api key'
+  end
+end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -14,12 +14,4 @@ describe UserSerializer do
   its(['id']) { should eq(user.id) }
   its(['name']) { should eq(user.name) }
   its(['email']) { should eq(user.email) }
-
-  context 'with a session api key' do
-    let(:api_key) { user.session_api_key }
-    let(:api_key_json) { user_json['user'] }
-    let(:expected_root_key) { 'sessionApiKey' }
-
-    it_behaves_like 'a serialized api key'
-  end
 end


### PR DESCRIPTION
The session api key is now only provided in the LoggedUserSerializer
which is used for the response of a successful sign in. All other places
that want to serialize a user (post author, editor) will use the
UserSerializer which omits the api key.

Fixes #4 
