### PR TITLE
Fetch default announcements for given bulletin

### DIFF
--- a/app/resources/basechurch/v1/announcement_resource.rb
+++ b/app/resources/basechurch/v1/announcement_resource.rb
@@ -7,18 +7,30 @@ class Basechurch::V1::AnnouncementResource < JSONAPI::Resource
   model_name 'Basechurch::Announcement'
 
   filter :latest_for_group
+  filter :defaults_for_bulletin
 
   def self.apply_filter(records, filter, value)
     case filter
     when :latest_for_group
       records.where('basechurch_announcements.bulletin_id = ?',
                     self.get_latest_bulletin!(value))
+    when :defaults_for_bulletin
+      records.where('basechurch_announcements.bulletin_id = ?',
+                    self.get_previous_bulletin(value))
     else
       return super(records, filter, value)
     end
   end
 
 private
+  def self.get_previous_bulletin(bulletin_id)
+    bulletin = Basechurch::Bulletin.where(id: bulletin_id).first
+    Basechurch::Bulletin.latest.
+                         where('published_at < ?', bulletin.published_at).
+                         where(group_id: bulletin.group_id).
+                         first
+  end
+
   def self.get_latest_bulletin!(group_id)
     latest_bulletin =
         Basechurch::Bulletin.latest.where(group_id: group_id).first


### PR DESCRIPTION
The `/v1/announcements?defaults_for_bulletin=:bulletin_id` endpoint will fetch all the announcements for the bulletin published right before the current bulletin's published_at date.