### PR TITLE
Add group slug to posts

### DIFF
--- a/app/resources/basechurch/v1/post_resource.rb
+++ b/app/resources/basechurch/v1/post_resource.rb
@@ -5,7 +5,8 @@ class Basechurch::V1::PostResource < JSONAPI::Resource
   attributes :content,
              :id,
              :slug,
-             :title;
+             :title,
+             :group_slug
 
   attribute :published_at, format: :iso8601
   attribute :updated_at, format: :iso8601
@@ -27,6 +28,10 @@ class Basechurch::V1::PostResource < JSONAPI::Resource
     else
       return super(records, filter, value)
     end
+  end
+
+  def group_slug
+    model.group.slug
   end
 
   def tags

--- a/spec/test_app/app/resources/basechurch/v1/post_resource_spec.rb
+++ b/spec/test_app/app/resources/basechurch/v1/post_resource_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Basechurch::V1::PostResource, :type => :resource do
   its(:id) { is_expected.to eq(post.id) }
   its(:content) { is_expected.to eq(post.content) }
   its(:published_at) { is_expected.to eq(post.published_at) }
+  its(:group_slug) { is_expected.to eq(post.group.slug) }
 
   describe "#group" do
     subject { resource.group.id }


### PR DESCRIPTION
This reduces an async call to fetch the group slug when fetching a post.