### PR TITLE
Refactor Bulletins into Bulletins and Sermons

### DIFF
--- a/app/controllers/api/v1/sermons_controller.rb
+++ b/app/controllers/api/v1/sermons_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::SermonsController < ApplicationResourceController
+  before_action :authenticate_user!, except: [:show]
+
+  def sign
+    render json: S3Signer.new.sign(type: params[:type], directory: "sermons"),
+           status: :ok
+  end
+end

--- a/app/controllers/api/v1/sermons_controller.rb
+++ b/app/controllers/api/v1/sermons_controller.rb
@@ -1,5 +1,8 @@
 class Api::V1::SermonsController < ApplicationResourceController
-  before_action :authenticate_user!, except: [:show]
+  before_action :authenticate_user!, except: [
+    :get_related_resource,
+    :show
+  ]
 
   def sign
     render json: S3Signer.new.sign(type: params[:type], directory: "sermons"),

--- a/app/models/bulletin.rb
+++ b/app/models/bulletin.rb
@@ -1,22 +1,17 @@
 class Bulletin < ActiveRecord::Base
   belongs_to :group
+  belongs_to :sermon
   has_many :announcements
+  has_attachment :audio # TODO remove when sermons fully migrated
+  has_attachment :banner
 
   validates :group, presence: true
   validates :published_at, presence: true
 
-  has_attachment :banner
-  has_attachment :audio
-
   scope :english_service, -> { for_group(1) }
   scope :for_group, -> (group_id) { where(group_id: group_id) }
-  scope :latest, -> do
-    published.order('published_at DESC')
-  end
-  scope :oldest, -> do
-    published.order('published_at')
-  end
-
+  scope :latest, -> { published.order('published_at DESC') }
+  scope :oldest, -> { published.order('published_at') }
   scope :published, -> { where('published_at <= ?', DateTime.now) }
 
   def self.next(bulletin, rollover: false)

--- a/app/models/sermon.rb
+++ b/app/models/sermon.rb
@@ -1,0 +1,9 @@
+class Sermon < ActiveRecord::Base
+  belongs_to :group
+
+  validates :published_at, presence: true
+  validates :group, presence: true
+  validates :speaker, presence: true
+
+  has_attachment :audio
+end

--- a/app/models/sermon.rb
+++ b/app/models/sermon.rb
@@ -6,4 +6,5 @@ class Sermon < ActiveRecord::Base
   validates :speaker, presence: true
 
   has_attachment :audio
+  has_attachment :banner
 end

--- a/app/resources/api/v1/bulletin_resource.rb
+++ b/app/resources/api/v1/bulletin_resource.rb
@@ -1,14 +1,10 @@
 class Api::V1::BulletinResource < JSONAPI::Resource
-  attributes :description,
-             :name,
-             :service_order,
-             :banner_url,
-             :audio_url,
-             :sermon_notes
+  attributes :name, :service_order, :banner_url
 
   attribute :published_at, format: :iso8601
 
   has_one :group
+  has_one :sermon
   has_many :announcements
 
   filter :latest_for_group

--- a/app/resources/api/v1/sermon_resource.rb
+++ b/app/resources/api/v1/sermon_resource.rb
@@ -1,0 +1,7 @@
+class Api::V1::SermonResource < JSONAPI::Resource
+  attributes :name, :notes, :speaker, :series, :banner_url, :audio_url
+  attribute :published_at, format: :iso8601
+
+  has_one :bulletin
+  has_one :group
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,12 @@ Rails.application.routes.draw do
         get "sign", on: :collection
       end
 
+      jsonapi_resources :sermons do
+        jsonapi_relationships
+
+        get "sign", on: :collection
+      end
+
       jsonapi_resources :bulletins do
         jsonapi_relationships
 

--- a/db/migrate/20160621012226_create_sermons.rb
+++ b/db/migrate/20160621012226_create_sermons.rb
@@ -2,6 +2,7 @@ class CreateSermons < ActiveRecord::Migration
   def change
     create_table :sermons do |t|
       t.references :group, index: true, foreign_key: true
+      t.string :name, null: false
       t.timestamp :published_at, null: false
       t.text :notes
       t.string :speaker, null: false

--- a/db/migrate/20160621012226_create_sermons.rb
+++ b/db/migrate/20160621012226_create_sermons.rb
@@ -1,0 +1,13 @@
+class CreateSermons < ActiveRecord::Migration
+  def change
+    create_table :sermons do |t|
+      t.references :group, index: true, foreign_key: true
+      t.timestamp :published_at, null: false
+      t.text :notes
+      t.string :speaker, null: false
+      t.string :series
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160624024551_add_sermon_id_to_bulletins.rb
+++ b/db/migrate/20160624024551_add_sermon_id_to_bulletins.rb
@@ -1,0 +1,5 @@
+class AddSermonIdToBulletins < ActiveRecord::Migration
+  def change
+    add_reference :bulletins, :sermon, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160414233629) do
+ActiveRecord::Schema.define(version: 20160621012226) do
 
   create_table "announcements", force: :cascade do |t|
     t.integer  "post_id"
@@ -102,6 +102,18 @@ ActiveRecord::Schema.define(version: 20160414233629) do
   add_index "posts", ["author_id"], name: "index_posts_on_author_id"
   add_index "posts", ["editor_id"], name: "index_posts_on_editor_id"
   add_index "posts", ["group_id"], name: "index_posts_on_group_id"
+
+  create_table "sermons", force: :cascade do |t|
+    t.integer  "group_id"
+    t.datetime "published_at", null: false
+    t.text     "notes"
+    t.string   "speaker",      null: false
+    t.string   "series"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "sermons", ["group_id"], name: "index_sermons_on_group_id"
 
   create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160621012226) do
+ActiveRecord::Schema.define(version: 20160624024551) do
 
   create_table "announcements", force: :cascade do |t|
     t.integer  "post_id"
@@ -57,7 +57,10 @@ ActiveRecord::Schema.define(version: 20160621012226) do
     t.datetime "updated_at"
     t.integer  "group_id"
     t.text     "sermon_notes"
+    t.integer  "sermon_id"
   end
+
+  add_index "bulletins", ["sermon_id"], name: "index_bulletins_on_sermon_id"
 
   create_table "friendly_id_slugs", force: :cascade do |t|
     t.string   "slug",                      null: false
@@ -105,6 +108,7 @@ ActiveRecord::Schema.define(version: 20160621012226) do
 
   create_table "sermons", force: :cascade do |t|
     t.integer  "group_id"
+    t.string   "name",         null: false
     t.datetime "published_at", null: false
     t.text     "notes"
     t.string   "speaker",      null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,83 +1,40 @@
 require "forgery"
 
-group = Group.create(name: 'English Service')
-user = User.create(email: 'test@example.com',
-                   password: 'password',
-                   provider: "email")
+group = Group.create!(name: 'English Service',
+                      target_audience: "Members and seekers",
+                      meet_details: "Sundays at 9:30am",
+                      short_description: "Worship service for the English congregation",
+                      about: "Welcome friends and visitors. We invite you to make MCAC your spiritual home and to worship with us every Sunday morning at 9:30am. Please let us know how we can be of help to you.
+
+The 2016 Church theme is [Equip to Shepherd](http://mcac.church/english-service/2016-church-theme-equip-to-shepherd). *“...to equip his people for works of service, so that the body of Christ may be built up”* (Ephesians 4:12)
+
+How can we pray for you? Let us know by [filling out a prayer request card](http://goo.gl/forms/vVNZxMsFFO).")
+User.create!(email: 'test@example.com',
+             password: 'password',
+             provider: "email")
+
+def service_order
+  " - ## Call to Worship
+ - ## Praise & Worship
+ - ## Announcements
+ - ## Offering
+ - ## Sermon
+   #{Forgery('lorem_ipsum').words(Random.rand(1..8), random: true).capitalize}  
+   #{["Pastor Ryan", "Rev. Thomas Chan", "Rev. Marshall Davis"].sample}  
+ - ## Doxology
+ - ## Benediction"
+end
 
 unless Rails.env.production?
-  service_order =
-    " - ## Call to Worship
-   - ## Praise & Worship
-   - ## Announcements
-   - ## Offering
-   - ## Holy Communion
-   - ## Sermon
-     \"We Will Love The World\"  
-     Genesis 2:4-15
-   - ## Doxology
-   - ## Benediction"
-
-  bulletin = Bulletin.create(published_at: DateTime.new(2010, 01, 3),
-                             group: group,
-                             name: 'Holy Communion New Year Sunday Service',
-                             description: 'January 3, 2010 at 9:30 am',
-                             service_order: service_order)
-  post = Post.create(author: user,
-                     group: group,
-                     title: 'This is a title',
-                     content: 'This is my post content',
-                     published_at: DateTime.now)
-
-  [
-    "**Welcome friends and visitors.** We invite you to make MCAC your spiritual
-  home. Please let us know how we can be of help to you.",
-    "The **2016 Church theme** is \"Equip to Shepherd\". *\"..to equip his people
-  for works of servce, so that the body of Christ may be built up\" (Ephesians
-  4:12)",
-    "We have received **162 pledge cards**, pledging an amount of **$103,510**.
-  If you have participated in the pledge, when you offer please specify
-  \"Missions\". Also remember to put 2016 as the year if you offer with checks.",
-    "Praise the Lord for the opportunities to reach out to our community through
-  the Christmas activities: the Celebrations in our 3 congregations, caroling in
-  an elderly home and with CCM's Christmas gifts to elderly and homeless... May
-  more people learn about the true meaning and the reason of Christmas.",
-    "Rev. Chan and Auntie Cindy have left for Hong Kong on Wednesday to visit
-  family and friends. They will return on the 21st of January.",
-    "There will be a **Jacob Fellowship** prayer meeting on Sunday, January 10
-  from 11:30am to 12:30pm in the library.",
-    "Sunday school classes will resume next Sunday.",
-    "There will be an Elders Board meeting on January 24th. 2016 ministry annual
-  report due the end of January. Annual Membership meeting takes place on
-  February 28th 11:30am after the joint service at 10am.",
-    "**2016 Church Directory** is now available. Ask ushers for a copy. 1 per
-  family.",
-    "**Church Renewal Weekend** offered by the Southland Church in Steinback, MB.
-  January 29 - February 1, 2016. Main speaker: Pastor Ray Duerksen. Fee for the
-  sessions: $139/person. Session and events include: Retreats, Ministry Tours,
-  Worships on Church Renewal and Hearing God, Prayer Summit and fellowships. For
-  more info, visit
-  [churchrenewalministry.com](http://www.churchrenewalministry.com)."
-  ].each_with_index do |a, i|
-    Announcement.create(post: post,
-                        bulletin: bulletin,
-                        description: a,
-                        position: i + 1)
-  end
-
   100.times do
-    service_order = ""
-    (5 + Random.rand(5)).times do
-      service_order = "#{service_order}\n- ## #{ Forgery('lorem_ipsum').word(random: true).capitalize } #{ Forgery('lorem_ipsum').words(Random.rand(3), random: true) }"
-    end
-
     bulletin =
-      Bulletin.create(published_at: Random.rand(1000).days.ago,
+      Bulletin.create!(published_at: Random.rand(1000).days.ago,
                       group: group,
                       name: Forgery('lorem_ipsum').title(random: true),
                       description: "#{ Forgery('lorem_ipsum').word(random: true).capitalize } #{ Forgery('lorem_ipsum').words(Random.rand(5), random: true) }",
                       service_order: service_order,
-                      sermon_notes: Forgery('email').body(random: true))
+                      sermon_notes: Forgery('email').body(random: true),
+                      audio_url: "https://mcac.s3.amazonaws.com/bulletins/70422ae2-7a4a-4932-93d6-3c5cf057f62c.mp3")
 
     (6 + Random.rand(5)).times do
       bulletin.announcements.build(description: Forgery('lorem_ipsum').sentences(Random.rand(7), random: true)).save

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,8 +33,10 @@ unless Rails.env.production?
                       name: Forgery('lorem_ipsum').title(random: true),
                       description: "#{ Forgery('lorem_ipsum').word(random: true).capitalize } #{ Forgery('lorem_ipsum').words(Random.rand(5), random: true) }",
                       service_order: service_order,
-                      sermon_notes: Forgery('email').body(random: true),
-                      audio_url: "https://mcac.s3.amazonaws.com/bulletins/70422ae2-7a4a-4932-93d6-3c5cf057f62c.mp3")
+                      sermon_notes: Forgery('email').body(random: true))
+
+    bulletin.audio_url = "https://mcac.s3.amazonaws.com/bulletins/70422ae2-7a4a-4932-93d6-3c5cf057f62c.mp3"
+    bulletin.save!
 
     (6 + Random.rand(5)).times do
       bulletin.announcements.build(description: Forgery('lorem_ipsum').sentences(Random.rand(7), random: true)).save

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,10 @@ group = Group.create!(name: 'English Service',
 The 2016 Church theme is [Equip to Shepherd](http://mcac.church/english-service/2016-church-theme-equip-to-shepherd). *“...to equip his people for works of service, so that the body of Christ may be built up”* (Ephesians 4:12)
 
 How can we pray for you? Let us know by [filling out a prayer request card](http://goo.gl/forms/vVNZxMsFFO).")
-User.create!(email: 'test@example.com',
-             password: 'password',
-             provider: "email")
+
+user = User.create!(email: 'test@example.com',
+                    password: 'password',
+                    provider: "email")
 
 def service_order
   " - ## Call to Worship
@@ -25,21 +26,34 @@ def service_order
  - ## Benediction"
 end
 
+def create_bulletin!(group)
+  bulletin =
+    Bulletin.create!(published_at: Random.rand(1000).days.ago,
+                    group: group,
+                    name: Forgery('lorem_ipsum').title(random: true),
+                    description: "#{ Forgery('lorem_ipsum').word(random: true).capitalize } #{ Forgery('lorem_ipsum').words(Random.rand(5), random: true) }",
+                    service_order: service_order,
+                    sermon_notes: Forgery('email').body(random: true))
+
+  bulletin.audio_url = "https://mcac.s3.amazonaws.com/bulletins/70422ae2-7a4a-4932-93d6-3c5cf057f62c.mp3"
+  bulletin.save!
+
+  (6 + Random.rand(5)).times do
+    bulletin.announcements.build(description: Forgery('lorem_ipsum').sentences(Random.rand(7), random: true)).save
+  end
+end
+
+def create_post!(group, author)
+  Post.create!(published_at: Random.rand(1000).days.ago,
+               group: group,
+               author: author,
+               title: Forgery('lorem_ipsum').title(random: true),
+               content: Forgery('email').body(random: true))
+end
+
 unless Rails.env.production?
   100.times do
-    bulletin =
-      Bulletin.create!(published_at: Random.rand(1000).days.ago,
-                      group: group,
-                      name: Forgery('lorem_ipsum').title(random: true),
-                      description: "#{ Forgery('lorem_ipsum').word(random: true).capitalize } #{ Forgery('lorem_ipsum').words(Random.rand(5), random: true) }",
-                      service_order: service_order,
-                      sermon_notes: Forgery('email').body(random: true))
-
-    bulletin.audio_url = "https://mcac.s3.amazonaws.com/bulletins/70422ae2-7a4a-4932-93d6-3c5cf057f62c.mp3"
-    bulletin.save!
-
-    (6 + Random.rand(5)).times do
-      bulletin.announcements.build(description: Forgery('lorem_ipsum').sentences(Random.rand(7), random: true)).save
-    end
+    create_bulletin!(group)
+    create_post!(group, user)
   end
 end

--- a/lib/tasks/migrate_sermons.rb
+++ b/lib/tasks/migrate_sermons.rb
@@ -1,0 +1,22 @@
+class MigrateSermons
+  def process
+    Bulletin.find_each do |b|
+      next unless b.audio_url
+      Sermon.create(group_id: b.group_id,
+                    published_at: b.published_at,
+                    audio_url: b.audio_url,
+                    notes: b.sermon_notes,
+                    speaker: speaker(b.service_order))
+    end
+  end
+
+  private
+
+  def speaker(string)
+    return "Pastor Ryan Lee" if string =~ /ryan|lee/i
+    return "Rev. Marshall Davis" if string =~ /marshall|davis/i
+    return "Rev. Thomas Chan" if string =~ /thomas|chan/i
+
+    return "MCAC"
+  end
+end

--- a/lib/tasks/migrate_sermons.rb
+++ b/lib/tasks/migrate_sermons.rb
@@ -4,6 +4,7 @@ class MigrateSermons
       next unless b.audio_url
       Sermon.create(group_id: b.group_id,
                     published_at: b.published_at,
+                    name: b.description,
                     audio_url: b.audio_url,
                     notes: b.sermon_notes,
                     speaker: speaker(b.service_order))

--- a/lib/tasks/migrate_sermons.rb
+++ b/lib/tasks/migrate_sermons.rb
@@ -2,12 +2,14 @@ class MigrateSermons
   def process
     Bulletin.find_each do |b|
       next unless b.audio_url
-      Sermon.create!(group_id: b.group_id,
-                     published_at: b.published_at,
-                     name: b.description,
-                     audio_url: b.audio_url,
-                     notes: b.sermon_notes,
-                     speaker: speaker(b.service_order))
+      sermon =
+        Sermon.create!(group_id: b.group_id,
+                       published_at: b.published_at,
+                       name: b.description,
+                       audio_url: b.audio_url,
+                       notes: b.sermon_notes,
+                       speaker: speaker(b.service_order))
+      b.update_attribute(:sermon_id, sermon.id)
     end
   end
 

--- a/lib/tasks/migrate_sermons.rb
+++ b/lib/tasks/migrate_sermons.rb
@@ -2,12 +2,12 @@ class MigrateSermons
   def process
     Bulletin.find_each do |b|
       next unless b.audio_url
-      Sermon.create(group_id: b.group_id,
-                    published_at: b.published_at,
-                    name: b.description,
-                    audio_url: b.audio_url,
-                    notes: b.sermon_notes,
-                    speaker: speaker(b.service_order))
+      Sermon.create!(group_id: b.group_id,
+                     published_at: b.published_at,
+                     name: b.description,
+                     audio_url: b.audio_url,
+                     notes: b.sermon_notes,
+                     speaker: speaker(b.service_order))
     end
   end
 

--- a/lib/tasks/sermons.rake
+++ b/lib/tasks/sermons.rake
@@ -1,0 +1,7 @@
+require "tasks/migrate_sermons"
+namespace :sermons do
+  desc "Convert bulletins into sermons"
+  task migrate: :environment do
+    MigrateSermons.new.process
+  end
+end

--- a/spec/controllers/api/v1/bulletins_controller_spec.rb
+++ b/spec/controllers/api/v1/bulletins_controller_spec.rb
@@ -14,7 +14,6 @@ describe Api::V1::BulletinsController, type: :controller do
         attributes: {
           :"published-at" => DateTime.now.to_time.iso8601,
           name: Forgery(:lorem_ipsum).title,
-          description: Forgery(:lorem_ipsum).words(10),
           :"service-order" => Forgery(:lorem_ipsum).words(10),
         },
         relationships: {
@@ -31,7 +30,6 @@ describe Api::V1::BulletinsController, type: :controller do
     create(:bulletin,
            published_at: DateTime.iso8601(b[:"published-at"]),
            name: b[:name],
-           description: b[:description],
            service_order: b[:"service-order"],
            group: english_service)
   end
@@ -79,11 +77,9 @@ describe Api::V1::BulletinsController, type: :controller do
       attributes = data["attributes"]
       expect(attributes["audioUrl"]).to eq bulletin.audio_url
       expect(attributes["bannerUrl"]).to eq bulletin.banner_url
-      expect(attributes["description"]).to eq bulletin.description
       expect(attributes["name"]).to eq bulletin.name
       expect(attributes["published-at"]).
         to eq bulletin.published_at.to_time.localtime("+00:00").iso8601
-      expect(attributes["sermonNotes"]).to eq bulletin.sermon_notes
       expect(attributes["service-order"]).to eq bulletin.service_order
 
       expect(data["relationships"]).to have_key("group")

--- a/spec/controllers/api/v1/sermons_controller_spec.rb
+++ b/spec/controllers/api/v1/sermons_controller_spec.rb
@@ -1,0 +1,152 @@
+require 'rails_helper'
+
+describe Api::V1::SermonsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:group) { create(:group) }
+
+  let(:all_attributes) do
+    {
+      data: {
+        type: "sermons",
+        attributes: {
+          :"published-at" => DateTime.now.to_time.iso8601,
+          name: Forgery(:lorem_ipsum).title,
+          notes: Forgery(:lorem_ipsum).words(10),
+          speaker: Forgery('name').full_name,
+          series: Forgery('lorem_ipsum').title
+        },
+        relationships: {
+          group: {
+            data: { type: "groups", id: group.id.to_s }
+          }
+        }
+      }
+    }
+  end
+
+  let(:full_sermon) do
+    b = all_attributes[:data][:attributes]
+    create(:sermon,
+           published_at: DateTime.iso8601(b[:"published-at"]),
+           name: b[:name],
+           notes: b[:notes],
+           speaker: b[:speaker],
+           series: b[:series],
+           group: group)
+  end
+
+  let(:valid_attributes) do
+    {
+      data: {
+        type: "sermons",
+        attributes: {
+          :"published-at" => DateTime.now.to_time.iso8601,
+          name: Forgery(:lorem_ipsum).title,
+          speaker: Forgery('name').full_name
+        },
+        relationships: {
+          group: {
+            data: { type: "groups", id: group.id.to_s }
+          }
+        }
+      }
+    }
+  end
+
+  shared_examples_for 'an action to create a sermon' do
+    let(:perform_action) { post :create, post_params }
+
+    it 'creates a new sermon' do
+      expect { perform_action }.to change { Sermon.count }.by(1)
+    end
+
+    context 'when successful' do
+      before { perform_action }
+      it_behaves_like 'a response containing a sermon'
+    end
+  end
+
+  shared_examples_for 'a response containing a sermon' do
+    it 'returns a sermon' do
+      data = JSON.parse(response.body)["data"]
+
+      expect(data["id"]).to be_present
+      expect(data["type"]).to eq "sermons"
+      attributes = data["attributes"]
+      expect(attributes["audioUrl"]).to eq sermon.audio_url
+      expect(attributes["bannerUrl"]).to eq sermon.banner_url
+      expect(attributes["name"]).to eq sermon.name
+      expect(attributes["published-at"]).
+        to eq sermon.published_at.to_time.localtime("+00:00").iso8601
+      expect(attributes["notes"]).to eq sermon.notes
+
+      expect(data["relationships"]).to have_key("group")
+      expect(data["relationships"]).to have_key("bulletin")
+    end
+  end
+
+  describe 'GET /sermons/:id' do
+    let(:sermon) { create(:sermon) }
+
+    before { get :show, id: sermon.id }
+
+    it_behaves_like 'a response containing a sermon'
+  end
+
+  describe "POST /sermons" do
+    let(:perform_action) { post :create, valid_attributes }
+
+    context 'with an authenticated user' do
+      before do
+        auth_headers =
+          user.create_new_auth_token.
+               merge("Content-Type" => "application/vnd.api+json")
+        @request.headers.merge!(auth_headers)
+      end
+
+      context 'with minimum params required' do
+        let(:post_params) { valid_attributes }
+        let(:sermon) do
+          iso_date = valid_attributes[:data][:attributes][:"published-at"]
+          create(:sermon,
+                 published_at: DateTime.iso8601(iso_date),
+                 name: valid_attributes[:data][:attributes][:name],
+                 notes: valid_attributes[:data][:attributes][:notes],
+                 speaker: valid_attributes[:data][:attributes][:speaker],
+                 group: group)
+        end
+
+        it_behaves_like 'an action to create a sermon'
+      end
+
+      context 'with all params provided' do
+        let(:post_params) { all_attributes }
+        let(:sermon) { full_sermon }
+        it_behaves_like 'an action to create a sermon'
+      end
+
+      context 'with invalid parameters' do
+        let(:invalid_attributes) { valid_attributes }
+
+        context "where published_at is not iso8601 compliant" do
+          before do
+            attributes = invalid_attributes[:data][:attributes]
+            attributes[:"published-at"] = "sdafasdfdsa"
+            perform_action
+          end
+
+          subject { response }
+
+          its(:status) { should == 422 }
+        end
+      end
+    end
+
+    it_behaves_like 'an authenticated action'
+  end
+
+  describe "s3 signing" do
+    let(:directory) { "sermons" }
+    it_behaves_like "a request that returns a signature to upload to s3"
+  end
+end

--- a/spec/lib/tasks/migrate_sermons_spec.rb
+++ b/spec/lib/tasks/migrate_sermons_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+require "tasks/migrate_sermons"
+
+RSpec.describe MigrateSermons, type: :model do
+  context "with a bulletin that does not have an audio file" do
+    subject(:process) { MigrateSermons.new.process }
+
+    before do
+      create(:bulletin)
+    end
+
+    it "does not migrate into a sermon" do
+      expect { process }.not_to change { Sermon.count }
+    end
+  end
+
+  context "with a bulletin that does have an audio file" do
+    subject { Sermon.last }
+
+    context "when the bulletin doesn't mention any expected speakers" do
+      let!(:bulletin) do
+        create(:bulletin,
+               audio_url: "http://nba.com/audio.mp3",
+               published_at: DateTime.now,
+               sermon_notes: "These are sermon notes")
+      end
+
+      before { MigrateSermons.new.process }
+
+      it "migrates a sermon from the bulletin" do
+        expect(subject.audio_url).to eq bulletin.audio_url
+        expect(subject.group_id).to eq bulletin.group_id
+        expect(subject.notes).to eq bulletin.sermon_notes
+        expect(subject.published_at).to eq bulletin.published_at
+        expect(subject.speaker).to eq "MCAC"
+        expect(subject.series).to be_nil
+      end
+    end
+
+    context "when the bulletin service order mentions Pastor Ryan" do
+      shared_examples_for "a sermon by expected speaker" do
+        it "migrates a sermon from the bulletin" do
+          speaker_values.each do |s|
+            create(:bulletin,
+                   audio_url: "http://nba.com/audio.mp3",
+                   service_order: "what #{s} what")
+            MigrateSermons.new.process
+            expect(Sermon.last.speaker).to eq expected_speaker
+          end
+        end
+      end
+
+      context "when it contains Pastor Ryan's name" do
+        let(:speaker_values) { %w{rYan LEE Ryan Lee lee ryan} }
+        let(:expected_speaker) { "Pastor Ryan Lee" }
+        it_behaves_like "a sermon by expected speaker"
+      end
+
+      context "when it contains Pastor Marshall's name" do
+        let(:speaker_values) { %w{Marshall Davis marshall} }
+        let(:expected_speaker) { "Rev. Marshall Davis" }
+        it_behaves_like "a sermon by expected speaker"
+      end
+
+      context "when it contains Rev. Chan's name" do
+        let(:speaker_values) { %w{Thomas Chan thomas chan} }
+        let(:expected_speaker) { "Rev. Thomas Chan" }
+        it_behaves_like "a sermon by expected speaker"
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/migrate_sermons_spec.rb
+++ b/spec/lib/tasks/migrate_sermons_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe MigrateSermons, type: :model do
         expect(subject.series).to be_nil
         expect(subject.speaker).to eq "MCAC"
         expect(subject.name).to eq bulletin.description
+        expect(bulletin.reload.sermon).to eq subject
       end
     end
 

--- a/spec/lib/tasks/migrate_sermons_spec.rb
+++ b/spec/lib/tasks/migrate_sermons_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe MigrateSermons, type: :model do
         expect(subject.audio_url).to eq bulletin.audio_url
         expect(subject.group_id).to eq bulletin.group_id
         expect(subject.notes).to eq bulletin.sermon_notes
-        expect(subject.published_at).to eq bulletin.published_at
+        expect(subject.published_at).
+          to be_within(1.second).of(bulletin.published_at)
         expect(subject.series).to be_nil
         expect(subject.speaker).to eq "MCAC"
         expect(subject.name).to eq bulletin.description

--- a/spec/lib/tasks/migrate_sermons_spec.rb
+++ b/spec/lib/tasks/migrate_sermons_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe MigrateSermons, type: :model do
         create(:bulletin,
                audio_url: "http://nba.com/audio.mp3",
                published_at: DateTime.now,
-               sermon_notes: "These are sermon notes")
+               sermon_notes: "These are sermon notes",
+               description: "random desc")
       end
 
       before { MigrateSermons.new.process }
@@ -32,8 +33,9 @@ RSpec.describe MigrateSermons, type: :model do
         expect(subject.group_id).to eq bulletin.group_id
         expect(subject.notes).to eq bulletin.sermon_notes
         expect(subject.published_at).to eq bulletin.published_at
-        expect(subject.speaker).to eq "MCAC"
         expect(subject.series).to be_nil
+        expect(subject.speaker).to eq "MCAC"
+        expect(subject.name).to eq bulletin.description
       end
     end
 
@@ -43,7 +45,8 @@ RSpec.describe MigrateSermons, type: :model do
           speaker_values.each do |s|
             create(:bulletin,
                    audio_url: "http://nba.com/audio.mp3",
-                   service_order: "what #{s} what")
+                   service_order: "what #{s} what",
+                   description: "random desc")
             MigrateSermons.new.process
             expect(Sermon.last.speaker).to eq expected_speaker
           end

--- a/spec/models/bulletin_spec.rb
+++ b/spec/models/bulletin_spec.rb
@@ -170,16 +170,16 @@ RSpec.describe Bulletin, type: :model do
     end
   end
 
-  context "#banner" do
-    let(:field) { "banner" }
-    let(:factory_name) { :bulletin }
-    let(:class_name) { "Bulletin" }
-    let(:update_attributes) { {} }
-    it_behaves_like "an attachment"
+  describe "#sermon" do
+    let(:sermon) { build(:sermon) }
+
+    it "can be associated to a sermon" do
+      expect(build(:bulletin, sermon: sermon).sermon).to eq sermon
+    end
   end
 
-  context "#audio" do
-    let(:field) { "audio" }
+  context "#banner" do
+    let(:field) { "banner" }
     let(:factory_name) { :bulletin }
     let(:class_name) { "Bulletin" }
     let(:update_attributes) { {} }

--- a/spec/models/sermon_spec.rb
+++ b/spec/models/sermon_spec.rb
@@ -26,4 +26,12 @@ RSpec.describe Sermon, :type => :model do
     let(:update_attributes) { {} }
     it_behaves_like "an attachment"
   end
+
+  context "#banner" do
+    let(:field) { "banner" }
+    let(:factory_name) { :sermon }
+    let(:class_name) { "Sermon" }
+    let(:update_attributes) { {} }
+    it_behaves_like "an attachment"
+  end
 end

--- a/spec/models/sermon_spec.rb
+++ b/spec/models/sermon_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Sermon, :type => :model do
+  describe 'validations' do
+    it "has a valid default factory" do
+      expect(create(:sermon)).to be_valid
+    end
+
+    it "requires a group" do
+      expect(build(:sermon, group: nil)).not_to be_valid
+    end
+
+    it "requires a speaker" do
+      expect(build(:sermon, speaker: nil)).not_to be_valid
+    end
+
+    it "requires a published_at" do
+      expect(build(:sermon, published_at: nil)).not_to be_valid
+    end
+  end
+
+  context "#audio" do
+    let(:field) { "audio" }
+    let(:factory_name) { :sermon }
+    let(:class_name) { "Sermon" }
+    let(:update_attributes) { {} }
+    it_behaves_like "an attachment"
+  end
+end

--- a/spec/resources/api/v1/bulletin_resource_spec.rb
+++ b/spec/resources/api/v1/bulletin_resource_spec.rb
@@ -2,29 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::BulletinResource, type: :resource do
   let(:bulletin) do
-    create(:bulletin_with_announcements,
-           banner_url: "http://banner.com",
-           audio_url: "http://audio.com",
-           sermon_notes: "these are sermon notes")
+    create(:bulletin_with_announcements, banner_url: "http://banner.com")
   end
   let(:resource) { Api::V1::BulletinResource.new(bulletin, nil) }
-  let(:group_resource) { Api::V1::GroupResource.new(bulletin.group, nil) }
 
   subject { resource }
 
-  its(:audio_url) { is_expected.to eq(bulletin.audio_url) }
   its(:banner_url) { is_expected.to eq(bulletin.banner_url) }
-  its(:description) { is_expected.to eq(bulletin.description) }
   its(:id) { is_expected.to eq(bulletin.id) }
   its(:name) { is_expected.to eq(bulletin.name) }
   its(:published_at) { is_expected.to eq(bulletin.published_at) }
-  its(:sermon_notes) { is_expected.to eq(bulletin.sermon_notes) }
   its(:service_order) { is_expected.to eq(bulletin.service_order) }
-
-  describe "#group" do
-    subject { resource.group.id }
-    it { is_expected.to eq(group_resource.id) }
-  end
 
   describe 'apply_filter' do
     let(:records) { Bulletin.all }
@@ -36,7 +24,7 @@ RSpec.describe Api::V1::BulletinResource, type: :resource do
     end
 
     context 'when filter is something else' do
-      let(:filter) { 'description' }
+      let(:filter) { 'name' }
       let(:value) { 'whatever' }
 
       it { is_expected.to eq([]) }

--- a/spec/resources/api/v1/sermon_resource_spec.rb
+++ b/spec/resources/api/v1/sermon_resource_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::SermonResource, type: :resource do
+  let(:sermon) do
+    create(:sermon,
+           banner_url: "http://#{Forgery("internet").domain_name}/profile.jpg",
+           audio_url: "http://#{Forgery("internet").domain_name}/profile.mp3")
+  end
+  let(:records) { Sermon.all }
+
+  subject { Api::V1::SermonResource.new(sermon, nil) }
+
+  its(:audio_url) { is_expected.to eq(sermon.audio_url) }
+  its(:banner_url) { is_expected.to eq(sermon.banner_url) }
+  its(:id) { is_expected.to eq(sermon.id) }
+  its(:name) { is_expected.to eq(sermon.name) }
+  its(:notes) { is_expected.to eq(sermon.notes) }
+  its(:series) { is_expected.to eq(sermon.series) }
+  its(:speaker) { is_expected.to eq(sermon.speaker) }
+end

--- a/spec/support/factories/bulletins.rb
+++ b/spec/support/factories/bulletins.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :bulletin do
     group
-    published_at DateTime.now
+    published_at { DateTime.now }
 
     factory :bulletin_with_announcements do
       transient do

--- a/spec/support/factories/sermons.rb
+++ b/spec/support/factories/sermons.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :sermon do
+    group
+    published_at { DateTime.now }
+    speaker { Forgery('name').full_name }
+  end
+end

--- a/spec/support/factories/sermons.rb
+++ b/spec/support/factories/sermons.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :sermon do
     group
+    name { Forgery('lorem_ipsum').sentence }
     published_at { DateTime.now }
     speaker { Forgery('name').full_name }
   end


### PR DESCRIPTION
Models

bulletins
 - id
 - published_at
 - name
 - REMOVE description
 - service_order
 - created_at
 - updated_at
 - group_id
 - REMOVE sermon_notes

sermons
 - id
 - group_id
 - published_at
 - notes
 - speaker
 - series


Migration Steps:

 - Create sermons table
 - Create script to populate sermons